### PR TITLE
Normalizes destination paths and skips local dirs.

### DIFF
--- a/src/main/java/org/springframework/build/aws/maven/AbstractWagon.java
+++ b/src/main/java/org/springframework/build/aws/maven/AbstractWagon.java
@@ -257,7 +257,11 @@ abstract class AbstractWagon implements Wagon {
     public final void putDirectory(File sourceDirectory, String destinationDirectory) throws TransferFailedException, ResourceDoesNotExistException,
         AuthorizationException {
         for (File f : sourceDirectory.listFiles()) {
-            put(f, destinationDirectory + "/" + f.getName());
+            if (f.isDirectory()) {
+                putDirectory(f, destinationDirectory + "/" + f.getName());
+            } else {
+                put(f, destinationDirectory + "/" + f.getName());
+            }
         }
     }
 

--- a/src/main/java/org/springframework/build/aws/maven/SimpleStorageServiceWagon.java
+++ b/src/main/java/org/springframework/build/aws/maven/SimpleStorageServiceWagon.java
@@ -202,11 +202,6 @@ public final class SimpleStorageServiceWagon extends AbstractWagon {
 
         mkdirs(key, 0);
 
-        if (source.isDirectory()) {
-            LOG.debug(String.format("Skiping directory: '%s'", source));
-            return;
-        }
-
         InputStream in = null;
         try {
             ObjectMetadata objectMetadata = new ObjectMetadata();


### PR DESCRIPTION
Maven site tries to push relative paths beginning with './/', even when
the site <url> tag is properly configured. This patch normalizes remote
folders fixing the "Signature does not match" erros caused when
deploying site.

Also, maven tries to push local directories, passing them to the wagon
without the proper leading slash. This patch adds trailing slash to
remote path and skips local paths to avoid an excepion when opening the
InputStream on a local directory.
