### PR TITLE
Use password instead of passphrase to store the AWS secret key

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,6 @@ target
 .classpath
 .project
 .settings
+/.idea/
+atlassian-ide-plugin.xml
+*.iml

--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ To publish Maven artifacts to S3 a build extension must be defined in a project'
 	            <extension>
 	                <groupId>org.springframework.build</groupId>
 	                <artifactId>aws-maven</artifactId>
-	                <version>4.4.0.RELEASE</version>
+	                <version>5.0.0.RELEASE</version>
 	            </extension>
 	            ...
 	        </extensions>
@@ -52,12 +52,12 @@ Finally the `~/.m2/settings.xml` must be updated to include access and secret ke
 	        <server>
 	            <id>aws-release</id>
 	            <username>0123456789ABCDEFGHIJ</username>
-	            <passphrase>0123456789abcdefghijklmnopqrstuvwxyzABCD</passphrase>
+	            <password>0123456789abcdefghijklmnopqrstuvwxyzABCD</password>
 	        </server>
 	        <server>
 	            <id>aws-snapshot</id>
 	            <username>0123456789ABCDEFGHIJ</username>
-	            <passphrase>0123456789abcdefghijklmnopqrstuvwxyzABCD</passphrase>
+	            <password>0123456789abcdefghijklmnopqrstuvwxyzABCD</password>
 	        </server>
 	        ...
 	    </servers>

--- a/pom.xml
+++ b/pom.xml
@@ -13,12 +13,12 @@
 	<description>Standard Maven wagon support for s3:// urls</description>
 
 	<properties>
-		<amazonaws.version>1.4.3</amazonaws.version>
+		<amazonaws.version>1.6.0</amazonaws.version>
 		<junit.version>4.11</junit.version>
 		<logback.version>1.0.12</logback.version>
 		<mockito.version>1.9.5</mockito.version>
 		<slf4j.version>1.7.5</slf4j.version>
-		<wagon.version>2.4</wagon.version>
+		<wagon.version>2.5</wagon.version>
 
 		<project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
 	</properties>

--- a/src/main/java/org/springframework/build/aws/maven/AuthenticationInfoAWSCredentials.java
+++ b/src/main/java/org/springframework/build/aws/maven/AuthenticationInfoAWSCredentials.java
@@ -35,6 +35,6 @@ final class AuthenticationInfoAWSCredentials implements AWSCredentials {
 
     @Override
     public String getAWSSecretKey() {
-        return this.authenticationInfo.getPassphrase();
+        return this.authenticationInfo.getPassword();
     }
 }

--- a/src/test/java/org/springframework/build/aws/maven/AbstractWagonTests.java
+++ b/src/test/java/org/springframework/build/aws/maven/AbstractWagonTests.java
@@ -50,7 +50,7 @@ import org.apache.maven.wagon.repository.Repository;
 import org.apache.maven.wagon.resource.Resource;
 import org.junit.Test;
 
-public final class AbstraktWagonTests {
+public final class AbstractWagonTests {
 
     private final SessionListenerSupport sessionListenerSupport = mock(SessionListenerSupport.class);
 

--- a/src/test/java/org/springframework/build/aws/maven/AuthenticationInfoAwsCredentialsTests.java
+++ b/src/test/java/org/springframework/build/aws/maven/AuthenticationInfoAwsCredentialsTests.java
@@ -37,7 +37,7 @@ public final class AuthenticationInfoAwsCredentialsTests {
 
     @Test
     public void getAWSSecretKey() {
-        when(this.authenticationInfo.getPassphrase()).thenReturn("foo");
+        when(this.authenticationInfo.getPassword()).thenReturn("foo");
         assertEquals("foo", this.awsCredentials.getAWSSecretKey());
     }
 

--- a/src/test/java/org/springframework/build/aws/maven/SimpleStorageServiceWagonIntegrationTests.java
+++ b/src/test/java/org/springframework/build/aws/maven/SimpleStorageServiceWagonIntegrationTests.java
@@ -76,27 +76,41 @@ public final class SimpleStorageServiceWagonIntegrationTests {
 
     private final SimpleStorageServiceWagon wagon = new SimpleStorageServiceWagon(this.amazonS3, BUCKET_NAME, BASE_DIRECTORY);
 
+
     @Test
     public void regionConnections() throws WagonException {
         SimpleStorageServiceWagon remoteConnectingWagon = new SimpleStorageServiceWagon();
 
         AuthenticationInfo authenticationInfo = new AuthenticationInfo();
         authenticationInfo.setUserName(System.getProperty("access.key"));
-        authenticationInfo.setPassphrase(System.getProperty("secret.key"));
+        authenticationInfo.setPassword(System.getProperty("secret.key"));
 
-        String[] buckets = new String[] { //
-        "test.aws-maven.ireland", //
-            "test.aws-maven.eu", //
-            "test.aws-maven.northern-california", //
-            "test.aws-maven.oregon", //
-            "test.aws-maven.sao-paulo", //
-            "test.aws-maven.singapore", //
-            "test.aws-maven.sydney", //
-            "test.aws-maven.tokyo", //
-            "test.aws-maven.us" //
-        };
+        assertNotNull(authenticationInfo.getUserName());
+        assertNotNull(authenticationInfo.getPassword());
+
+        String bucketsSysProp = System.getProperty("buckets");
+        String[] buckets;
+        if (bucketsSysProp != null && !bucketsSysProp.trim().isEmpty()) {
+            buckets = bucketsSysProp.split(",");
+            for (int i=0; i < buckets.length; i++) {
+                buckets[i] = buckets[i].trim();
+            }
+        } else {
+            buckets = new String[] { //
+                "test.aws-maven.ireland", //
+                "test.aws-maven.eu", //
+                "test.aws-maven.northern-california", //
+                "test.aws-maven.oregon", //
+                "test.aws-maven.sao-paulo", //
+                "test.aws-maven.singapore", //
+                "test.aws-maven.sydney", //
+                "test.aws-maven.tokyo", //
+                "test.aws-maven.us" //
+            };
+        }
 
         for (String bucket : buckets) {
+
             Repository repository = new Repository("test", String.format("s3://%s/", bucket));
             remoteConnectingWagon.connectToRepository(repository, authenticationInfo, null);
             assertNotNull(remoteConnectingWagon.getFileList(""));


### PR DESCRIPTION
I'm using maven 3, I don't know why the passphrase is not being sent to the plugin, so, why not using the password? here's my patch
