### PR TITLE
Added Amazon IAM section in the README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,4 +64,24 @@ Finally the `~/.m2/settings.xml` must be updated to include access and secret ke
 	    ...
 	</settings>
 
+Note that [Amazon IAM][iam] permissions need to be configured accordingly. The `s3:GetBucketLocation` action is required in addition to the bucket read/write permission.
+
+	{
+	  "Statement": [
+	    {
+	      "Effect": "Allow",
+	      "Action": "s3:*",
+	      "Resource": "arn:aws:s3:::distribution.bucket/*"
+	    }
+	  ],
+	  "Statement": [
+	    {
+	      "Effect": "Allow",
+	      "Action": "s3:GetBucketLocation",
+	      "Resource": "arn:aws:s3:::*"
+	    }
+	  ]
+	}
+
 [aws-maven]: http://search.maven.org/#search%7Cgav%7C1%7Cg%3A%22org.springframework.build%22%20AND%20a%3A%22aws-maven%22
+[iam]: http://aws.amazon.com/iam/


### PR DESCRIPTION
When upgrading the plugin from 3.0.0.RELEASE to 5.0.0.RELEASE, I bumped into this permission issue where 5.0.0.RELEASE uses `AmazonS3Client.getBucketLocation()`,  which requires a new permission to be added compared to the 3.0.0.RELEASE.  I hope this note will save some time for others who are also seeking for upgrade as well.
