### PR TITLE
Adding information about the configuration with a proxy

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,6 +74,29 @@ Alternatively, the access and secret keys for the account can be provided using
 * `aws.accessKeyId` and `aws.secretKey` [system properties][sys-prop]
 * The Amazon EC2 [Instance Metadata Service][instance-metadata]
 
+## Connecting through a Proxy
+For being able to connect behind an HTTP proxy you need to add the following configuration to `~/.m2/settings.xml`:
+
+```xml
+<settings>
+  ...
+  <proxies>
+     ...
+     <proxy>
+         <active>true</active>
+         <protocol>s3</protocol>
+         <host>myproxy.host.com</host>
+         <port>8080</port>
+         <username>proxyuser</username>
+         <password>somepassword</password>
+         <nonProxyHosts>www.google.com|*.somewhere.com</nonProxyHosts>
+     </proxy>
+     ...
+    </proxies>
+  ...
+</settings>
+```
+
 ## Making Artifacts Public
 This wagon doesn't set an explict ACL for each artfact that is uploaded.  Instead you should create an AWS Bucket Policy to set permissions on objects.  A bucket policy can be set in the [AWS Console][console] and can be generated using the [AWS Policy Generator][policy-generator].
 
@@ -172,27 +195,3 @@ aws s3api put-bucket-policy --bucket $BUCKET --policy "$POLICY"
 [s3]: http://aws.amazon.com/s3/
 [sys-prop]: http://docs.aws.amazon.com/AWSJavaSDK/latest/javadoc/com/amazonaws/auth/SystemPropertiesCredentialsProvider.html
 [wagon]: http://maven.apache.org/wagon/
-
-## Connecting through an HTTP Proxy
-
-You need to add the following configuration to your settings.xml file:
-
-```xml
-<settings>
-  ...
-  <proxies>
-     ...
-     <proxy>
-         <active>true</active>
-         <protocol>s3</protocol>
-         <host>myproxy.host.com</host>
-         <port>8080</port>
-         <username>proxyuser</username>
-         <password>somepassword</password>
-         <nonProxyHosts>www.google.com|*.somewhere.com</nonProxyHosts>
-     </proxy>
-     ...
-    </proxies>
-  ...
-</settings>
-```

--- a/README.md
+++ b/README.md
@@ -172,3 +172,27 @@ aws s3api put-bucket-policy --bucket $BUCKET --policy "$POLICY"
 [s3]: http://aws.amazon.com/s3/
 [sys-prop]: http://docs.aws.amazon.com/AWSJavaSDK/latest/javadoc/com/amazonaws/auth/SystemPropertiesCredentialsProvider.html
 [wagon]: http://maven.apache.org/wagon/
+
+## Connecting through an HTTP Proxy
+
+You need to add the following configuration to your settings.xml file:
+
+```xml
+<settings>
+  ...
+  <proxies>
+     ...
+     <proxy>
+         <active>true</active>
+         <protocol>s3</protocol>
+         <host>myproxy.host.com</host>
+         <port>8080</port>
+         <username>proxyuser</username>
+         <password>somepassword</password>
+         <nonProxyHosts>www.google.com|*.somewhere.com</nonProxyHosts>
+     </proxy>
+     ...
+    </proxies>
+  ...
+</settings>
+```


### PR DESCRIPTION
It would be great if we add this information because I think is not straightforward. I tried many times with `http` protocol until I inspect the code and I noticed it was expecting `s3` protocol.
