### PR TITLE
Update aws-java-sdk to support AWS Signature Version 4. Add support for EU Frankfurt region.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -11,7 +11,7 @@
 	<description>Standard Maven wagon support for s3:// urls</description>
 
 	<properties>
-		<amazonaws.version>1.7.1</amazonaws.version>
+		<amazonaws.version>1.9.13</amazonaws.version>
 		<junit.version>4.11</junit.version>
 		<logback.version>1.1.1</logback.version>
 		<mockito.version>1.9.5</mockito.version>

--- a/src/main/java/org/springframework/build/aws/maven/Region.java
+++ b/src/main/java/org/springframework/build/aws/maven/Region.java
@@ -21,6 +21,7 @@ enum Region {
     US_WEST_OREGON("us-west-2", "s3-us-west-2.amazonaws.com"), //
     US_WEST_NORTHERN_CALIFORNIA("us-west-1", "s3-us-west-1.amazonaws.com"), //
     EU("EU", "s3-eu-west-1.amazonaws.com"), //
+    EU_FRANKFURT("eu-central-1", "s3-eu-central-1.amazonaws.com"), //
     EU_IRELAND("eu-west-1", "s3-eu-west-1.amazonaws.com"), //
     GOV_CLOUD("us-gov-west-1", "us-gov-west-1.amazonaws.com"), //
     ASIA_PACIFIC_SINGAPORE("ap-southeast-1", "s3-ap-southeast-1.amazonaws.com"), //


### PR DESCRIPTION
The aws-java-sdk version is not up-to-date and does not support new AWS signature version 4.
Also, the identifier and address of S3 in EU Frankfurt region is missing.
