### PR TITLE
added shaded jar build and instructions for use in deploy:deploy-file

### DIFF
--- a/README.md
+++ b/README.md
@@ -172,3 +172,42 @@ aws s3api put-bucket-policy --bucket $BUCKET --policy "$POLICY"
 [s3]: http://aws.amazon.com/s3/
 [sys-prop]: http://docs.aws.amazon.com/AWSJavaSDK/latest/javadoc/com/amazonaws/auth/SystemPropertiesCredentialsProvider.html
 [wagon]: http://maven.apache.org/wagon/
+
+## Usage in deploy:deploy-file
+If you'd like to use aws-maven via `mvn deploy:deploy-file` to deploy non-maven jars to your s3 maven repo, you might want to install the aws-maven wagon provider and all of its dependencies into your maven installation's lib directory, so that the aws-maven wagon provider is available outside of the context of a project and its pom.xml. Here's one way to do that:
+
+1. Uncomment the section in this project's pom.xml containing the shaded jar build.
+
+2. Build this project
+
+		mvn clean package
+ or if you find that an integration test fails
+ 
+ 		mvn -DskipTests=true clean package
+ 	
+3. Copy the shaded jar into your $MAVEN_HOME/lib
+
+ First, find your maven home:
+
+		$ mvn -v
+		Apache Maven 3.2.3 (33f8c3e1027c3ddde99d3cdebad2656a31e8fdf4; 2014-08-11T16:58:10-04:00)
+		Maven home: /usr/local/Cellar/maven/3.2.3/libexec
+		Java version: 1.7.0_40, vendor: Oracle Corporation
+		Java home: /Library/Java/JavaVirtualMachines/jdk1.7.0_40.jdk/Contents/Home/jre
+		Default locale: en_US, platform encoding: UTF-8
+		OS name: "mac os x", version: "10.9.5", arch: "x86_64", family: "mac"
+	
+ Now copy the shaded jar into your maven home:
+
+		cp target/aws-maven-wagon.jar /usr/local/Cellar/maven/3.2.3/libexec/lib
+	
+4. Deploy your non-maven jar using a deploy:deploy-file command similar to this:
+	
+		mvn deploy:deploy-file \
+		    -Dfile=example.jar \
+		    -DgroupId=com.example \
+		    -DartifactId=example \
+		    -Dversion=1.0.0 \
+		    -Dpackaging=jar \
+		    -DrepositoryId=aws-release \
+		    -Durl=s3://<BUCKET>/release

--- a/README.md
+++ b/README.md
@@ -176,14 +176,12 @@ aws s3api put-bucket-policy --bucket $BUCKET --policy "$POLICY"
 ## Usage in deploy:deploy-file
 If you'd like to use aws-maven via `mvn deploy:deploy-file` to deploy non-maven jars to your s3 maven repo, you might want to install the aws-maven wagon provider and all of its dependencies into your maven installation's lib directory, so that the aws-maven wagon provider is available outside of the context of a project and its pom.xml. Here's one way to do that:
 
-1. Uncomment the section in this project's pom.xml containing the shaded jar build.
+1. Build this project
 
-2. Build this project
-
-		mvn clean package
+		mvn clean package -PshadedWagon
  or if you find that an integration test fails
  
- 		mvn -DskipTests=true clean package
+ 		mvn -DskipTests=true clean package -PshadedWagon
  	
 3. Copy the shaded jar into your $MAVEN_HOME/lib
 

--- a/pom.xml
+++ b/pom.xml
@@ -117,29 +117,35 @@
                 <artifactId>sonar-maven-plugin</artifactId>
                 <version>2.2</version>
             </plugin>
-                        <!-- Uncomment this section to build a shaded jar
-                             (which you can install into your $MAVEN_HOME/lib
-                             in order to use aws-maven via 'mvn deploy:deploy-file')
-                        -->
-                        <!--
-			<plugin>
-				<groupId>org.apache.maven.plugins</groupId>
-				<artifactId>maven-shade-plugin</artifactId>
-				<executions>
-					<execution>
-						<phase>package</phase>
-						<goals>
-							<goal>shade</goal>
-						</goals>
-						<configuration>
-							<outputFile>target/aws-maven-wagon.jar</outputFile>
-						</configuration>
-					</execution>
-				</executions>
-			</plugin>
-			-->
 		</plugins>
 	</build>
+	
+	<profiles>
+		<profile>
+			<!-- Activate this profile to build a shaded jar (which you can install into your $MAVEN_HOME/lib in order to use aws-maven via 'mvn deploy:deploy-file') -->
+			<id>shadedWagon</id>
+			<build>
+				<plugins>
+					<plugin>
+						<groupId>org.apache.maven.plugins</groupId>
+						<artifactId>maven-shade-plugin</artifactId>
+						<version>3.0.0</version>
+						<executions>
+							<execution>
+								<phase>package</phase>
+								<goals>
+									<goal>shade</goal>
+								</goals>
+								<configuration>
+									<outputFile>target/aws-maven-wagon.jar</outputFile>
+								</configuration>
+							</execution>
+						</executions>
+					</plugin>
+				</plugins>
+			</build>
+		</profile>
+	</profiles>
 
 	<url>https://github.com/spring-projects/aws-maven</url>
 

--- a/pom.xml
+++ b/pom.xml
@@ -117,6 +117,27 @@
                 <artifactId>sonar-maven-plugin</artifactId>
                 <version>2.2</version>
             </plugin>
+                        <!-- Uncomment this section to build a shaded jar
+                             (which you can install into your $MAVEN_HOME/lib
+                             in order to use aws-maven via 'mvn deploy:deploy-file')
+                        -->
+                        <!--
+			<plugin>
+				<groupId>org.apache.maven.plugins</groupId>
+				<artifactId>maven-shade-plugin</artifactId>
+				<executions>
+					<execution>
+						<phase>package</phase>
+						<goals>
+							<goal>shade</goal>
+						</goals>
+						<configuration>
+							<outputFile>target/aws-maven-wagon.jar</outputFile>
+						</configuration>
+					</execution>
+				</executions>
+			</plugin>
+			-->
 		</plugins>
 	</build>
 

--- a/src/main/java/org/springframework/build/aws/maven/AuthenticationInfoAWSCredentialsProviderChain.java
+++ b/src/main/java/org/springframework/build/aws/maven/AuthenticationInfoAWSCredentialsProviderChain.java
@@ -17,17 +17,13 @@
 package org.springframework.build.aws.maven;
 
 import com.amazonaws.auth.AWSCredentialsProviderChain;
-import com.amazonaws.auth.EnvironmentVariableCredentialsProvider;
-import com.amazonaws.auth.InstanceProfileCredentialsProvider;
-import com.amazonaws.auth.SystemPropertiesCredentialsProvider;
+import com.amazonaws.auth.DefaultAWSCredentialsProviderChain;
 import org.apache.maven.wagon.authentication.AuthenticationInfo;
 
 final class AuthenticationInfoAWSCredentialsProviderChain extends AWSCredentialsProviderChain {
 
     AuthenticationInfoAWSCredentialsProviderChain(AuthenticationInfo authenticationInfo) {
-        super(new EnvironmentVariableCredentialsProvider(),
-                new SystemPropertiesCredentialsProvider(),
-                new InstanceProfileCredentialsProvider(),
+        super(new DefaultAWSCredentialsProviderChain(),
                 new AuthenticationInfoAWSCredentialsProvider(authenticationInfo));
     }
 }


### PR DESCRIPTION
I'd like to use this S3 Wagon provider for deploy:deploy-file operations and possibly other invocation types that are outside of the context of a project. I thought this might be helpful to other users of aws-maven, so here is a way you might share that (leaving the relevant pom.xml section commented out but including instructions on the README to help users who are less familiar with custom wagon providers).

This is similar to #29 though it doesn't solve that issue.
