### PR TITLE
Removing explicit permission declaration on directory creation

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -13,7 +13,7 @@
 	<properties>
 		<amazonaws.version>1.7.1</amazonaws.version>
 		<junit.version>4.11</junit.version>
-		<logback.version>1.1.1</logback.version>
+		<logback.version>1.2.0</logback.version>
 		<mockito.version>1.9.5</mockito.version>
 		<slf4j.version>1.7.6</slf4j.version>
 		<wagon.version>2.6</wagon.version>

--- a/pom.xml
+++ b/pom.xml
@@ -12,7 +12,7 @@
 
 	<properties>
 		<amazonaws.version>1.7.1</amazonaws.version>
-		<junit.version>4.11</junit.version>
+		<junit.version>4.13.1</junit.version>
 		<logback.version>1.1.1</logback.version>
 		<mockito.version>1.9.5</mockito.version>
 		<slf4j.version>1.7.6</slf4j.version>

--- a/src/main/java/org/springframework/build/aws/maven/SimpleStorageServiceWagon.java
+++ b/src/main/java/org/springframework/build/aws/maven/SimpleStorageServiceWagon.java
@@ -245,7 +245,7 @@ public final class SimpleStorageServiceWagon extends AbstractWagon {
         ObjectMetadata objectMetadata = new ObjectMetadata();
         objectMetadata.setContentLength(0);
 
-        return new PutObjectRequest(this.bucketName, key, inputStream, objectMetadata).withCannedAcl(CannedAccessControlList.PublicRead);
+        return new PutObjectRequest(this.bucketName, key, inputStream, objectMetadata);
     }
 
 }

--- a/src/test/java/org/springframework/build/aws/maven/SimpleStorageServiceWagonIntegrationTest.java
+++ b/src/test/java/org/springframework/build/aws/maven/SimpleStorageServiceWagonIntegrationTest.java
@@ -234,7 +234,6 @@ public final class SimpleStorageServiceWagonIntegrationTest {
             assertEquals(BUCKET_NAME, putObjectRequests.get(i).getBucketName());
             assertNotNull(putObjectRequests.get(i).getInputStream());
             assertEquals(0, putObjectRequests.get(i).getMetadata().getContentLength());
-            assertEquals(CannedAccessControlList.PublicRead, putObjectRequests.get(i).getCannedAcl());
         }
 
         assertEquals("foo/", putObjectRequests.get(0).getKey());


### PR DESCRIPTION
As per #8 and #20, the permissions should be defined on the bucket, not explicitly by the wagon - this change removes the public-read permission from directory creation. 
