### PR TITLE
Set an endpoint even if the bucket location cannot be determined.

### DIFF
--- a/src/main/java/org/springframework/build/aws/maven/SimpleStorageServiceWagon.java
+++ b/src/main/java/org/springframework/build/aws/maven/SimpleStorageServiceWagon.java
@@ -83,8 +83,13 @@ public final class SimpleStorageServiceWagon extends AbstractWagon {
             this.baseDirectory = S3Utils.getBaseDirectory(repository);
 
             this.amazonS3 = new AmazonS3Client(credentialsProvider, clientConfiguration);
-            Region region = Region.fromLocationConstraint(this.amazonS3.getBucketLocation(this.bucketName));
-            this.amazonS3.setEndpoint(region.getEndpoint());
+	    try {
+                Region region = Region.fromLocationConstraint(this.amazonS3.getBucketLocation(this.bucketName));
+                this.amazonS3.setEndpoint(region.getEndpoint());
+            } catch (AmazonS3Exception ae) {
+                //most likely not the bucket owner, set some default
+		this.amazonS3.setEndpoint(Region.US.getEndpoint());
+            }
         }
     }
 


### PR DESCRIPTION
If your user is not the bucket owner, the plugin fails with

```
com.amazonaws.services.s3.model.AmazonS3Exception: Status Code: 403, AWS Service: Amazon S3, AWS Request ID: , AWS Error Code: AccessDenied, AWS Error Message: Access Denied, S3 Extended Request ID:
```
