### PR TITLE
Add missing eu-central-1 region

### DIFF
--- a/src/main/java/org/springframework/build/aws/maven/Region.java
+++ b/src/main/java/org/springframework/build/aws/maven/Region.java
@@ -22,6 +22,7 @@ enum Region {
     US_WEST_NORTHERN_CALIFORNIA("us-west-1", "s3-us-west-1.amazonaws.com"), //
     EU("EU", "s3-eu-west-1.amazonaws.com"), //
     EU_IRELAND("eu-west-1", "s3-eu-west-1.amazonaws.com"), //
+    EU_FRANKFURT("eu-central-1", "s3-eu-central-1.amazonaws.com"), //
     GOV_CLOUD("us-gov-west-1", "us-gov-west-1.amazonaws.com"), //
     ASIA_PACIFIC_SINGAPORE("ap-southeast-1", "s3-ap-southeast-1.amazonaws.com"), //
     ASIA_PACIFIC_SYDNEY("ap-southeast-2", "s3-ap-southeast-2.amazonaws.com"), //

--- a/src/test/java/org/springframework/build/aws/maven/RegionTest.java
+++ b/src/test/java/org/springframework/build/aws/maven/RegionTest.java
@@ -28,6 +28,7 @@ public final class RegionTest {
         assertEndpoint("us-west-2", "s3-us-west-2.amazonaws.com");
         assertEndpoint("us-west-1", "s3-us-west-1.amazonaws.com");
         assertEndpoint("EU", "s3-eu-west-1.amazonaws.com");
+        assertEndpoint("eu-central-1", "s3-eu-central-1.amazonaws.com");
         assertEndpoint("ap-southeast-1", "s3-ap-southeast-1.amazonaws.com");
         assertEndpoint("ap-southeast-2", "s3-ap-southeast-2.amazonaws.com");
         assertEndpoint("ap-northeast-1", "s3-ap-northeast-1.amazonaws.com");


### PR DESCRIPTION
Not sure why you're not using the Region classes from the AWS SDK but here is a simple patch adding this missing region.
