### PR TITLE
Fixing the endpoint for the s3 gov cloud region

### DIFF
--- a/src/main/java/org/springframework/build/aws/maven/Region.java
+++ b/src/main/java/org/springframework/build/aws/maven/Region.java
@@ -22,7 +22,7 @@ enum Region {
     US_WEST_NORTHERN_CALIFORNIA("us-west-1", "s3-us-west-1.amazonaws.com"), //
     EU("EU", "s3-eu-west-1.amazonaws.com"), //
     EU_IRELAND("eu-west-1", "s3-eu-west-1.amazonaws.com"), //
-    GOV_CLOUD("us-gov-west-1", "us-gov-west-1.amazonaws.com"), //
+    GOV_CLOUD("us-gov-west-1", "s3-us-gov-west-1.amazonaws.com"), //
     ASIA_PACIFIC_SINGAPORE("ap-southeast-1", "s3-ap-southeast-1.amazonaws.com"), //
     ASIA_PACIFIC_SYDNEY("ap-southeast-2", "s3-ap-southeast-2.amazonaws.com"), //
     ASIA_PACIFIC_TOKYO("ap-northeast-1", "s3-ap-northeast-1.amazonaws.com"), //


### PR DESCRIPTION
gov cloud region endpoint is incorrect which prevents use of this extension for releases in gov-cloud