### PR TITLE
Removing public acls

### DIFF
--- a/src/main/java/org/springframework/build/aws/maven/SimpleStorageServiceWagon.java
+++ b/src/main/java/org/springframework/build/aws/maven/SimpleStorageServiceWagon.java
@@ -245,7 +245,7 @@ public final class SimpleStorageServiceWagon extends AbstractWagon {
         ObjectMetadata objectMetadata = new ObjectMetadata();
         objectMetadata.setContentLength(0);
 
-        return new PutObjectRequest(this.bucketName, key, inputStream, objectMetadata).withCannedAcl(CannedAccessControlList.PublicRead);
+        return new PutObjectRequest(this.bucketName, key, inputStream, objectMetadata);
     }
 
 }

--- a/src/test/java/org/springframework/build/aws/maven/SimpleStorageServiceWagonIntegrationTest.java
+++ b/src/test/java/org/springframework/build/aws/maven/SimpleStorageServiceWagonIntegrationTest.java
@@ -234,7 +234,6 @@ public final class SimpleStorageServiceWagonIntegrationTest {
             assertEquals(BUCKET_NAME, putObjectRequests.get(i).getBucketName());
             assertNotNull(putObjectRequests.get(i).getInputStream());
             assertEquals(0, putObjectRequests.get(i).getMetadata().getContentLength());
-            assertEquals(CannedAccessControlList.PublicRead, putObjectRequests.get(i).getCannedAcl());
         }
 
         assertEquals("foo/", putObjectRequests.get(0).getKey());


### PR DESCRIPTION
According to the [README](https://github.com/spring-projects/aws-maven/blob/master/README.md#making-artifacts-public), this plugin will not set public ACLs.  We need this to be the case for internal use.