### PR TITLE
Update aws sdk and DefaultAWSCredentialsProviderChain

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -11,7 +11,7 @@
 	<description>Standard Maven wagon support for s3:// urls</description>
 
 	<properties>
-		<amazonaws.version>1.7.1</amazonaws.version>
+		<amazonaws.version>1.11.384</amazonaws.version>
 		<junit.version>4.11</junit.version>
 		<logback.version>1.1.1</logback.version>
 		<mockito.version>1.9.5</mockito.version>

--- a/src/main/java/org/springframework/build/aws/maven/AuthenticationInfoAWSCredentialsProviderChain.java
+++ b/src/main/java/org/springframework/build/aws/maven/AuthenticationInfoAWSCredentialsProviderChain.java
@@ -17,6 +17,7 @@
 package org.springframework.build.aws.maven;
 
 import com.amazonaws.auth.AWSCredentialsProviderChain;
+import com.amazonaws.auth.DefaultAWSCredentialsProviderChain;
 import com.amazonaws.auth.EnvironmentVariableCredentialsProvider;
 import com.amazonaws.auth.InstanceProfileCredentialsProvider;
 import com.amazonaws.auth.SystemPropertiesCredentialsProvider;
@@ -25,7 +26,8 @@ import org.apache.maven.wagon.authentication.AuthenticationInfo;
 final class AuthenticationInfoAWSCredentialsProviderChain extends AWSCredentialsProviderChain {
 
     AuthenticationInfoAWSCredentialsProviderChain(AuthenticationInfo authenticationInfo) {
-        super(new EnvironmentVariableCredentialsProvider(),
+        super(new DefaultAWSCredentialsProviderChain(),
+        		new EnvironmentVariableCredentialsProvider(),
                 new SystemPropertiesCredentialsProvider(),
                 new InstanceProfileCredentialsProvider(),
                 new AuthenticationInfoAWSCredentialsProvider(authenticationInfo));


### PR DESCRIPTION
Fixing #65. Added DefaultAWSCredentialsProviderChain and upgraded aws-java-sdk to 1.11.384. Can someone merge and release version? Thanks