### PR TITLE
URL Cleanup

### DIFF
--- a/NOTICE
+++ b/NOTICE
@@ -4,13 +4,13 @@
    ======================================================================
 
    This product includes software developed by
-   the Apache Software Foundation (http://www.apache.org).
+   the Apache Software Foundation (https://www.apache.org).
 
    The end-user documentation included with a redistribution, if any,
    must include the following acknowledgement:
 
      "This product includes software developed by the Spring Build
-      Project (http://www.springframework.org)."
+      Project (https://www.springframework.org)."
 
    Alternately, this acknowledgement may appear in the software itself,
    if and wherever such third-party acknowledgements normally appear.

--- a/README.md
+++ b/README.md
@@ -163,12 +163,12 @@ EOF
 aws s3api put-bucket-policy --bucket $BUCKET --policy "$POLICY"
 ```
 
-[aws-maven]: http://search.maven.org/#search%7Cgav%7C1%7Cg%3A%22org.springframework.build%22%20AND%20a%3A%22aws-maven%22
-[cli]: http://aws.amazon.com/documentation/cli/
+[aws-maven]: https://search.maven.org/#search%7Cgav%7C1%7Cg%3A%22org.springframework.build%22%20AND%20a%3A%22aws-maven%22
+[cli]: https://aws.amazon.com/documentation/cli/
 [console]: https://console.aws.amazon.com/s3
-[env-var]: http://docs.aws.amazon.com/AWSJavaSDK/latest/javadoc/com/amazonaws/auth/EnvironmentVariableCredentialsProvider.html
-[instance-metadata]: http://docs.aws.amazon.com/AWSJavaSDK/latest/javadoc/com/amazonaws/auth/InstanceProfileCredentialsProvider.html
-[policy-generator]: http://awspolicygen.s3.amazonaws.com/policygen.html
-[s3]: http://aws.amazon.com/s3/
-[sys-prop]: http://docs.aws.amazon.com/AWSJavaSDK/latest/javadoc/com/amazonaws/auth/SystemPropertiesCredentialsProvider.html
-[wagon]: http://maven.apache.org/wagon/
+[env-var]: https://docs.aws.amazon.com/AWSJavaSDK/latest/javadoc/com/amazonaws/auth/EnvironmentVariableCredentialsProvider.html
+[instance-metadata]: https://docs.aws.amazon.com/AWSJavaSDK/latest/javadoc/com/amazonaws/auth/InstanceProfileCredentialsProvider.html
+[policy-generator]: https://awspolicygen.s3.amazonaws.com/policygen.html
+[s3]: https://aws.amazon.com/s3/
+[sys-prop]: https://docs.aws.amazon.com/AWSJavaSDK/latest/javadoc/com/amazonaws/auth/SystemPropertiesCredentialsProvider.html
+[wagon]: https://maven.apache.org/wagon/


### PR DESCRIPTION
This commit updates URLs to prefer the https protocol. Redirects are not followed to avoid accidentally expanding intentionally shortened URLs (i.e. if using a URL shortener).

# Fixed URLs

## Fixed Success 
These URLs were switched to an https URL with a 2xx status. While the status was successful, your review is still recommended.

* [ ] http://aws.amazon.com/documentation/cli/ with 1 occurrences migrated to:  
  https://aws.amazon.com/documentation/cli/ ([https](https://aws.amazon.com/documentation/cli/) result 200).
* [ ] http://aws.amazon.com/s3/ with 1 occurrences migrated to:  
  https://aws.amazon.com/s3/ ([https](https://aws.amazon.com/s3/) result 200).
* [ ] http://awspolicygen.s3.amazonaws.com/policygen.html with 1 occurrences migrated to:  
  https://awspolicygen.s3.amazonaws.com/policygen.html ([https](https://awspolicygen.s3.amazonaws.com/policygen.html) result 200).
* [ ] http://docs.aws.amazon.com/AWSJavaSDK/latest/javadoc/com/amazonaws/auth/EnvironmentVariableCredentialsProvider.html with 1 occurrences migrated to:  
  https://docs.aws.amazon.com/AWSJavaSDK/latest/javadoc/com/amazonaws/auth/EnvironmentVariableCredentialsProvider.html ([https](https://docs.aws.amazon.com/AWSJavaSDK/latest/javadoc/com/amazonaws/auth/EnvironmentVariableCredentialsProvider.html) result 200).
* [ ] http://docs.aws.amazon.com/AWSJavaSDK/latest/javadoc/com/amazonaws/auth/InstanceProfileCredentialsProvider.html with 1 occurrences migrated to:  
  https://docs.aws.amazon.com/AWSJavaSDK/latest/javadoc/com/amazonaws/auth/InstanceProfileCredentialsProvider.html ([https](https://docs.aws.amazon.com/AWSJavaSDK/latest/javadoc/com/amazonaws/auth/InstanceProfileCredentialsProvider.html) result 200).
* [ ] http://docs.aws.amazon.com/AWSJavaSDK/latest/javadoc/com/amazonaws/auth/SystemPropertiesCredentialsProvider.html with 1 occurrences migrated to:  
  https://docs.aws.amazon.com/AWSJavaSDK/latest/javadoc/com/amazonaws/auth/SystemPropertiesCredentialsProvider.html ([https](https://docs.aws.amazon.com/AWSJavaSDK/latest/javadoc/com/amazonaws/auth/SystemPropertiesCredentialsProvider.html) result 200).
* [ ] http://maven.apache.org/wagon/ with 1 occurrences migrated to:  
  https://maven.apache.org/wagon/ ([https](https://maven.apache.org/wagon/) result 200).
* [ ] http://search.maven.org/ with 1 occurrences migrated to:  
  https://search.maven.org/ ([https](https://search.maven.org/) result 200).
* [ ] http://www.apache.org with 1 occurrences migrated to:  
  https://www.apache.org ([https](https://www.apache.org) result 200).
* [ ] http://www.springframework.org with 1 occurrences migrated to:  
  https://www.springframework.org ([https](https://www.springframework.org) result 301).